### PR TITLE
Fix access token retrieval

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.0
 beautifulsoup4>=4.8.1
+lxml>=4.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.0
+beautifulsoup4>=4.8.1


### PR DESCRIPTION
Fixes #1 

Spotify changed the way the access token is retrieved.
Instead of being able to get as a cookie it now needs to be grabbed from a script tag.

Thanks to @AlexLadd @bendikrb and @fondberg for finding a way to fix this.