### PR TITLE
Read requirements of package from requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@ from setuptools import setup
 with open('README.rst') as rd:
     long_description = rd.read()
 
+with open("requirements.txt") as rq:
+    requirements = rq.read().splitlines()
+
 setup(
     name='spotify_token',
     py_modules=['spotify_token'],
@@ -12,7 +15,7 @@ setup(
     author_email='egonzalezh94@gmail.com',
     license='MIT',
     url='https://github.com/enriquegh/spotify-webplayer-token',
-    install_requires=['requests'],
+    install_requires=requirements,
     long_description=long_description,
     keywords=['wrapper', 'spotify'],
     classifiers=["Programming Language :: Python :: 3",


### PR DESCRIPTION
Some requirements are missing in `setup.py` which breaks installation via pip. 

I changed the file to read the requirements from `requirements.txt`, which now acts as a single point of truth.